### PR TITLE
require continual-local-storage

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,6 +26,12 @@ module.exports = {
   create: create
 };
 
+/*
+ Some fittings utilize 'async'.  This breaks continual-local-storage (cls) if being used.
+ Require cls before async to preserve the callbacks
+ */
+var cls = require('continuation-local-storage');
+
 var _ = require('lodash');
 var yaml = require('js-yaml');
 var path = require('path');

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "bagpipes": "^0.1.0",
     "body-parser": "^1.14.1",
     "config": "^1.16.0",
+    "continuation-local-storage": "^3.1.7",
     "cors": "^2.5.3",
     "debug": "^2.1.3",
     "js-yaml": "^3.3.0",


### PR DESCRIPTION
Some fitting use 'async' which breaks 'cls' if being used.  Requiring 'cls' before 'async' preserves the chain.